### PR TITLE
Make LuaEncode available on pesde

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 
 # LuaEncode doesn't use any 3rd party modules
 /wally.lock
+/pesde.lock
+/luau_packages
+/lune_packages
 
 # Misc
+/.pesde
 /.vscode

--- a/pesde.toml
+++ b/pesde.toml
@@ -8,8 +8,8 @@ license = "MIT"
 includes = ["README.md", "pesde.toml", "src/**"]
 
 [target]
-environment = "lune"
-lib = "src/LuaEncode.luau"
+environment = "luau"
+lib = "src/LuaEncode.lua"
 build_files = ["src"]
 
 [indices]

--- a/pesde.toml
+++ b/pesde.toml
@@ -1,5 +1,5 @@
 name = "chadhyatt/luaencode"
-version = "0.1.0"
+version = "1.4.4"
 description = "Fast table serialization library for pure Luau/Lua 5.1+"
 authors = ["Chad Hyatt <chad@hyatt.page>"]
 repository = "https://github.com/chadhyatt/LuaEncode"

--- a/pesde.toml
+++ b/pesde.toml
@@ -1,0 +1,24 @@
+name = "chadhyatt/luaencode"
+version = "0.1.0"
+description = "Fast table serialization library for pure Luau/Lua 5.1+"
+authors = ["Chad Hyatt <chad@hyatt.page>"]
+repository = "https://github.com/chadhyatt/LuaEncode"
+license = "MIT"
+
+includes = ["README.md", "pesde.toml", "src/**"]
+
+[target]
+environment = "lune"
+lib = "src/LuaEncode.luau"
+build_files = ["src"]
+
+[indices]
+default = "https://github.com/pesde-pkg/index"
+
+[scripts]
+roblox_sync_config_generator = ".pesde/scripts/roblox_sync_config_generator.luau"
+sourcemap_generator = ".pesde/scripts/sourcemap_generator.luau"
+
+[dev_dependencies]
+scripts = { name = "pesde/scripts_rojo", version = "^0.1.1", target = "lune" }
+rojo = { name = "pesde/rojo", version = "^7.4.4", target = "lune" }


### PR DESCRIPTION
This PR adds one file `pesde.toml`, to define the package configuration for publishing to pesde, and updates the `.gitignore` file to account for the new pesde-generated files.

*cf. https://docs.pesde.dev/guides/publishing/*